### PR TITLE
Revert "Ensure MPI installation"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,0 @@
-[deps]
-LoopVectorization = "bdcacae8-bdee-11e8-abc2-f30e1b3014d5"
-NCDatasets = "85a47980-1005-43f5-8004-0a2b9e5078c7"
-Parameters = "d96e819e-233e-5a43-8a1f-62d0d9b1caaa"
-MPI = "d1bd81bf-4b4a-5dfc-86a2-aa54b3badeba"
-

--- a/README.md
+++ b/README.md
@@ -3,27 +3,12 @@ Two-dimensional moist simulation model with fully compressible non‑hydrostatic
 
 ## Running tests
 
-Execute the following commands from the project directory. Activate the
-project with `--project` so that the bundled dependencies are used:
+Execute the following commands from the project directory:
 
 ```bash
-
 # Run tests in single precision (Float32)
-julia --project test/runtests.jl
+julia test/runtests.jl
 
 # Run tests in double precision (Float64)
-julia --project test/runtests.jl Float64
+julia test/runtests.jl Float64
 ```
-
-## Installing dependencies
-
-All required packages are listed in `Project.toml`. Before running the
-simulation or the tests, activate the project and instantiate the
-environment:
-
-```bash
-julia --project -e 'using Pkg; Pkg.instantiate()'
-```
-
-Running Julia with `--project` ensures that the correct versions of all
-dependencies, including `MPI`, are available.

--- a/install_deps.jl
+++ b/install_deps.jl
@@ -1,0 +1,29 @@
+import Pkg
+
+code = read("moist.jl", String)
+
+mods = Set{String}()
+
+for line in eachline(IOBuffer(code))
+    s = strip(line)
+    if startswith(s, "using ") || startswith(s, "import ")
+        parts = split(s, r"[ ,]+")
+        for part in parts[2:end]
+            m = match(r"^([A-Za-z_]\w*)", part)
+            if m !== nothing
+                push!(mods, m.captures[1])
+            end
+        end
+    end
+end
+
+for pkg in mods
+    fp = Base.find_package(pkg)
+    if fp === nothing || (isa(fp, String) && isempty(fp))
+        println("Adding ", pkg)
+        Pkg.add(pkg)
+    end
+end
+
+Pkg.resolve()
+


### PR DESCRIPTION
Reverts seiya/moist2d#21


以下のエラーで失敗する

```
    Updating registry at `~/.julia/registries/General.toml`
ERROR: 
expected package `NCDatasets [85a47980]` to be registered
Stacktrace:
  [1] pkgerror(msg::String)
    @ Pkg.Types /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/Types.jl:68
  [2] check_registered
    @ /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:1329 [inlined]
  [3] up(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}, level::Pkg.Types.UpgradeLevel; skip_writing_project::Bool, preserve::Nothing)
    @ Pkg.Operations /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:1632
  [4] up
    @ /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:1612 [inlined]
  [5] up(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; level::Pkg.Types.UpgradeLevel, mode::Pkg.Types.PackageMode, preserve::Nothing, update_registry::Bool, skip_writing_project::Bool, kwargs::@Kwargs{})
    @ Pkg.API /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:388
  [6] up
    @ /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:362 [inlined]
  [7] up
    @ /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:164 [inlined]
  [8] instantiate(ctx::Pkg.Types.Context; manifest::Nothing, update_registry::Bool, verbose::Bool, platform::Base.BinaryPlatforms.Platform, allow_build::Bool, allow_autoprecomp::Bool, kwargs::@Kwargs{})
    @ Pkg.API /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:1196
  [9] instantiate
    @ /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:1172 [inlined]
 [10] instantiate(; kwargs::@Kwargs{})
    @ Pkg.API /tmp/julia-1.11.5/share/julia/stdlib/v1.11/Pkg/src/API.jl:1171
 [11] top-level scope
    @ none:1
```